### PR TITLE
add support for kubeadm

### DIFF
--- a/cmd/build_bin.go
+++ b/cmd/build_bin.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var supportBinaryName []string = []string{"kubelet", "kubectl"}
+var supportBinaryName []string = []string{"kubelet", "kubectl", "kubeadm"}
 
 var binCmd = &cobra.Command{
 	Use:   "bin",


### PR DESCRIPTION
版本号 
- tags -> .dockerized-kube-version-defs 
- build/build-image/cross/VERSION
- build/build-image/VERSION
- cmd/kubeadm/app/constants/constants.go （支持的最大最小版本） upgrade

kubedev  bin kubeadm

